### PR TITLE
webadmin: don't put the Generate button on the login page

### DIFF
--- a/webadmin/static/admin-add.js
+++ b/webadmin/static/admin-add.js
@@ -124,10 +124,18 @@
         return btn;
     }
 
-    // Add-form variant: single "passphrase" field. Used on
-    // /admin/add via the admin_list.html "Add a new entry" form.
+    // Add-form variant: single "passphrase" field. Scoped to the
+    // admin "Add a new entry" form (admin_list.html), NOT the login
+    // form — both fields are named "passphrase" so WTForms gives them
+    // the same id, but a Generate button has no business on the login
+    // page.
     function attachAddFormGenerator() {
-        var pw = document.getElementById('passphrase');
+        var form = document.querySelector('form.admin-add-form');
+        if (!form) {
+            return;
+        }
+        var pw = form.querySelector('#passphrase')
+                 || form.querySelector('input[name="passphrase"]');
         if (!pw || pw.dataset.generatorAttached) {
             return;
         }


### PR DESCRIPTION
LoginForm.passphrase and AdminAddForm.passphrase are both named "passphrase", so WTForms renders both with id="passphrase". The add-form Generate-button hook used getElementById('passphrase'), which matched the login form too — a passphrase generator showed up on the login page, which makes no sense there.

Scope attachAddFormGenerator() to the form.admin-add-form on the admin list page (the class was already on that <form>); the login page has no such form, so the button no longer appears there.