### PR TITLE
mavlink: use the 'all' dialect everywhere instead of ardupilotmega

### DIFF
--- a/binlog.cpp
+++ b/binlog.cpp
@@ -6,7 +6,7 @@
 #include "mavlink.h"
 #include "util.h"
 
-#include "libraries/mavlink2/generated/ardupilotmega/mavlink.h"
+#include "libraries/mavlink2/generated/all/mavlink.h"
 
 #include <algorithm>
 #include <dirent.h>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from test_config import (TEST_PORT_USER, TEST_PORT_ENGINEER, TEST_PASSPHRASE,
                          TEST_PORT_USER_BIDI, TEST_PORT_ENGINEER_BIDI,
                          KEYDB_PY, SUPPORTPROXY_BIN)
 
-os.environ['MAVLINK_DIALECT'] = 'ardupilotmega'
+os.environ['MAVLINK_DIALECT'] = 'all'
 os.environ['MAVLINK20'] = '1'  # Ensure MAVLink2 is used
 
 

--- a/tests/test_binlog_capture.py
+++ b/tests/test_binlog_capture.py
@@ -3,7 +3,7 @@
 We launch the real supportproxy binary against a fresh keys.tdb that
 has KEY_FLAG_BINLOG (and optionally KEY_FLAG_TLOG) set on a test
 entry, drive synthetic REMOTE_LOG_DATA_BLOCK packets through the
-user-side UDP port via pymavlink (using the ardupilotmega dialect),
+user-side UDP port via pymavlink (using the all dialect),
 and assert:
 
   * a sessionN.bin file appears at the expected sparse-file path,
@@ -47,7 +47,7 @@ PORT_ENG = 17801 + _W * 4
 PORT_USER_PAIR = 17900 + _W * 4
 PORT_ENG_PAIR = 17901 + _W * 4
 
-os.environ.setdefault('MAVLINK_DIALECT', 'ardupilotmega')
+os.environ.setdefault('MAVLINK_DIALECT', 'all')
 os.environ.setdefault('MAVLINK20', '1')
 
 
@@ -130,7 +130,7 @@ def _wait_for(predicate, timeout=5.0):
 def _send_data_block(sock, dest, seqno, payload, sysid=1):
     """Build + send a REMOTE_LOG_DATA_BLOCK from a fake vehicle.
     payload is padded/truncated to 200 bytes."""
-    from pymavlink.dialects.v20 import ardupilotmega as mav
+    from pymavlink.dialects.v20 import all as mav
     mav_obj = mav.MAVLink(file=None, srcSystem=sysid, srcComponent=1)
     data = (payload + b'\x00' * 200)[:200]
     msg = mav.MAVLink_remote_log_data_block_message(
@@ -145,7 +145,7 @@ def _send_system_time(sock, dest, time_boot_ms, sysid=1,
     """Send a SYSTEM_TIME from a fake autopilot. Default compid is
     MAV_COMP_ID_AUTOPILOT1 (= 1) — change it to simulate a camera or
     companion computer for filter tests."""
-    from pymavlink.dialects.v20 import ardupilotmega as mav
+    from pymavlink.dialects.v20 import all as mav
     if compid is None:
         compid = mav.MAV_COMP_ID_AUTOPILOT1
     mav_obj = mav.MAVLink(file=None, srcSystem=sysid, srcComponent=compid)
@@ -158,7 +158,7 @@ def _send_system_time(sock, dest, time_boot_ms, sysid=1,
 def _recv_block_statuses(sock, timeout=2.0):
     """Drain incoming UDP packets, decode REMOTE_LOG_BLOCK_STATUS,
     return list of (seqno, status) seen within `timeout`."""
-    from pymavlink.dialects.v20 import ardupilotmega as mav
+    from pymavlink.dialects.v20 import all as mav
     mav_obj = mav.MAVLink(file=None)
     sock.settimeout(0.1)
     out = []
@@ -328,7 +328,7 @@ class TestBinlogCapture:
             # has a chance to fire. A single quiet HEARTBEAT would
             # only trigger one tick before main_loop's idle-timeout
             # kicks in.
-            from pymavlink.dialects.v20 import ardupilotmega as mav
+            from pymavlink.dialects.v20 import all as mav
             hb_mav = mav.MAVLink(file=None, srcSystem=1, srcComponent=1)
             hb_msg = mav.MAVLink_heartbeat_message(
                 type=0, autopilot=0, base_mode=0, custom_mode=0,
@@ -346,7 +346,7 @@ class TestBinlogCapture:
                         collected.append(data)
                 except socket.timeout:
                     pass
-            from pymavlink.dialects.v20 import ardupilotmega as mav2
+            from pymavlink.dialects.v20 import all as mav2
             decoder = mav2.MAVLink(file=None)
             start_seqnos = []
             for blob in collected:
@@ -613,7 +613,7 @@ class TestBinlogCapture:
     def test_reboot_ignored_from_camera_compid(self, proxy_workdir):
         """A SYSTEM_TIME backward jump from a non-autopilot component
         (e.g. a camera) must NOT trigger rotation."""
-        from pymavlink.dialects.v20 import ardupilotmega as mav
+        from pymavlink.dialects.v20 import all as mav
         _setup_db(proxy_workdir, PORT_USER, PORT_ENG, 'bintest', 'bp',
                   'binlog')
         proc = _start_proxy(proxy_workdir, PORT_ENG)
@@ -694,7 +694,7 @@ class TestBinlogCapture:
         """After streaming begins, the proxy keeps sending START at
         ~5 s cadence so a post-reboot vehicle resumes. Pre-fix the
         START emit stopped after the first DATA_BLOCK."""
-        from pymavlink.dialects.v20 import ardupilotmega as mav
+        from pymavlink.dialects.v20 import all as mav
         _setup_db(proxy_workdir, PORT_USER, PORT_ENG, 'bintest', 'bp',
                   'binlog')
         proc = _start_proxy(proxy_workdir, PORT_ENG)

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -18,7 +18,7 @@ from test_config import (TEST_PORTS, TEST_PORTS_BIDI, TEST_PASSPHRASE,
                          MULTIPLE_CONNECTIONS_TEST_DURATION)
 
 # Set up environment for pymavlink
-os.environ['MAVLINK_DIALECT'] = 'ardupilotmega'
+os.environ['MAVLINK_DIALECT'] = 'all'
 os.environ['MAVLINK20'] = '1'  # Ensure MAVLink2 is used
 
 

--- a/tests/test_kill_drop.py
+++ b/tests/test_kill_drop.py
@@ -38,7 +38,7 @@ _W = int(os.environ.get('PYTEST_XDIST_WORKER', 'gw0')[2:]
 PORT_USER = 17600 + _W * 4
 PORT_ENG = 17601 + _W * 4
 
-os.environ.setdefault('MAVLINK_DIALECT', 'ardupilotmega')
+os.environ.setdefault('MAVLINK_DIALECT', 'all')
 os.environ.setdefault('MAVLINK20', '1')
 
 

--- a/tests/test_tlog_capture.py
+++ b/tests/test_tlog_capture.py
@@ -38,7 +38,7 @@ _W = int(os.environ.get('PYTEST_XDIST_WORKER', 'gw0')[2:]
 PORT_USER = 17500 + _W * 4
 PORT_ENG  = 17501 + _W * 4
 
-os.environ.setdefault('MAVLINK_DIALECT', 'ardupilotmega')
+os.environ.setdefault('MAVLINK_DIALECT', 'all')
 os.environ.setdefault('MAVLINK20', '1')
 
 


### PR DESCRIPTION
binlog.cpp included the ardupilotmega dialect header while the rest of the proxy (mavlink_msgs.h) already used the 'all' dialect. Switch binlog.cpp and the pytest harness over to 'all' so a single dialect is used throughout: the include in binlog.cpp, the MAVLINK_DIALECT env var in the test modules, and the pymavlink dialect imports in test_binlog_capture.py.

MAV_AUTOPILOT_ARDUPILOTMEGA references are left as-is: that's an autopilot-type enum constant present in the 'all' dialect, not a dialect selection.